### PR TITLE
added -it to weave status

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ docker run -d --name mysql \
 You can get the status of the weave network by running the `status` command:
 
 ```bash
-$ docker run --rm \
+$ docker run --rm -it \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/bin/docker:/usr/bin/docker \
     binocarlos/powerstrip-weave status


### PR DESCRIPTION
using -it on the docker run for the weave status will cause the output to actually print, otherwise it's not printed and the container is removed with --rm, so it can't even be inspected via docker logs